### PR TITLE
Revert change to segment reader path

### DIFF
--- a/tail/tail.go
+++ b/tail/tail.go
@@ -62,7 +62,7 @@ func Tail(ctx context.Context, dir string) (*Tailer, error) {
 		}
 		// Open the entire checkpoint first. It has to be consumed before
 		// the tailer proceeds to any segments.
-		t.cur, err = wal.NewSegmentsReader(filepath.Join(dir, cpdir))
+		t.cur, err = wal.NewSegmentsReader(cpdir)
 		if err != nil {
 			return nil, errors.Wrap(err, "open checkpoint")
 		}


### PR DESCRIPTION
My fix for upstream issue: https://github.com/Stackdriver/stackdriver-prometheus-sidecar/issues/160

Also closes: https://github.com/overleaf/google-ops/issues/463